### PR TITLE
update and pin typescript to 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5525,9 +5525,9 @@
       "optional": true
     },
     "typescript": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
+      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
       "dev": true
     },
     "uid2": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "npm-run-all": "^4.1.1",
     "nyc": "^11.0.2",
     "nyc-config-100": "^1.0.1",
-    "typescript": "^2.5.3"
+    "typescript": "2.6.1"
   },
   "nyc": {
     "extends": "nyc-config-100",


### PR DESCRIPTION
Yeah, this is better. TypeScript do not adhere to semver in the language itself. Every single release, even patch, could break your compilation.