### PR TITLE
allow failure in ci in node_js: node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
   - lts/*
   - node
+matrix:
+  allow_failures:
+    - node_js: node
 before_install:
   - npm install -g npm@5
   - npm install -g greenkeeper-lockfile@1


### PR DESCRIPTION
Currently, doing what we do for greenkeeper-lockfile, `npm -g i npm@5` crashes on `node_js: node` (node v9).

This is a workaround until npm release support for Node.js 9.

https://github.com/npm/npm/issues/19019