### PR TITLE
Do not install npm5 manually

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - lts/*
   - node
 before_install:
-  - npm install -g npm@5
   - npm install -g greenkeeper-lockfile@1
 before_script: greenkeeper-lockfile-update
 after_script:


### PR DESCRIPTION
At the time we are testing in node 8 and 9. Both 8 and 9 include npm@5
so there is no reason to install npm5 manually.