### PR TITLE
Pin typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "npm-run-all": "^4.1.2",
     "nyc": "^11.3.0",
     "nyc-config-100": "^1.0.1",
-    "typescript": "^2.6.2",
+    "typescript": "2.6.2",
     "typescript-eslint-parser": "^11.0.0"
   },
   "nyc": {


### PR DESCRIPTION
## Pin typescript due to it doesn't follow semver.

Creating this PR after discussion in https://github.com/tjoskar/simple-spy/pull/27

I still don't really see the point of pin it ;) but I wanted to create this PR to continue the discussion. 

Since we are using `packge-lock.json` we will always get the same version of typescript (2.6.2) unless we delete `packge-lock.json` or manually upgrade typescript. 

Greenkeep will run the test suite for every new version (regardless if it's in the range or not) https://greenkeeper.io/faq.html#branch-deletions but it will only create a PR if it brakes or if the new version is above the version range.

So the only difference between pining and declare a range is that we will get a PR for every new version if we pin it: https://greenkeeper.io/faq.html#pinning-versions so I do not really see the point of pin it, even though it doesn't follow semver. 

But I can be wrong ;)
